### PR TITLE
Split fix

### DIFF
--- a/components/mitsubishi_heatpump/climate.py
+++ b/components/mitsubishi_heatpump/climate.py
@@ -23,7 +23,7 @@ CONF_VERTICAL_SWING_SELECT = "vertical_vane_select"
 DEFAULT_CLIMATE_MODES = ["HEAT_COOL", "COOL", "HEAT", "DRY", "FAN_ONLY"]
 DEFAULT_FAN_MODES = ["AUTO", "DIFFUSE", "LOW", "MEDIUM", "MIDDLE", "HIGH"]
 DEFAULT_SWING_MODES = ["OFF", "VERTICAL"]
-HORIZONTAL_SWING_OPTIONS = ["auto","left","left_center","center","right_center","right","swing"]
+HORIZONTAL_SWING_OPTIONS = ["left", "left_center", "center", "right_center", "right", "split", "swing"]
 VERTICAL_SWING_OPTIONS = ["auto", "up", "up_center", "center", "down_center", "down","swing"]
 
 # Remote temperature timeout configuration

--- a/components/mitsubishi_heatpump/climate.py
+++ b/components/mitsubishi_heatpump/climate.py
@@ -23,16 +23,8 @@ CONF_VERTICAL_SWING_SELECT = "vertical_vane_select"
 DEFAULT_CLIMATE_MODES = ["HEAT_COOL", "COOL", "HEAT", "DRY", "FAN_ONLY"]
 DEFAULT_FAN_MODES = ["AUTO", "DIFFUSE", "LOW", "MEDIUM", "MIDDLE", "HIGH"]
 DEFAULT_SWING_MODES = ["OFF", "VERTICAL"]
-HORIZONTAL_SWING_OPTIONS = [
-    "auto",
-    "swing",
-    "left",
-    "left_center",
-    "center",
-    "right_center",
-    "right",
-]
-VERTICAL_SWING_OPTIONS = ["swing", "auto", "up", "up_center", "center", "down_center", "down"]
+HORIZONTAL_SWING_OPTIONS = ["auto","left","left_center","center","right_center","right","swing"]
+VERTICAL_SWING_OPTIONS = ["auto", "up", "up_center", "center", "down_center", "down","swing"]
 
 # Remote temperature timeout configuration
 CONF_REMOTE_OPERATING_TIMEOUT = "remote_temperature_operating_timeout_minutes"

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -194,7 +194,7 @@ void MitsubishiHeatPump::on_horizontal_swing_change(const std::string &swing) {
     if (swing == "swing") {
         hp->setWideVaneSetting("SWING");
         updated = true;
-    } else if (swing == "auto") {
+    } else if (swing == "split") {
         hp->setWideVaneSetting("<>");
         updated = true;
     } else if (swing == "left") {
@@ -525,7 +525,7 @@ void MitsubishiHeatPump::hpSettingsChanged() {
     if (strcmp(currentSettings.wideVane, "SWING") == 0) {
         this->update_swing_horizontal("swing");
     } else if (strcmp(currentSettings.wideVane, "<>") == 0) {
-        this->update_swing_horizontal("auto");
+        this->update_swing_horizontal("split");
     } else if (strcmp(currentSettings.wideVane, "<<") == 0) {
         this->update_swing_horizontal("left");
     } else if (strcmp(currentSettings.wideVane, "<") == 0) {

--- a/components/mitsubishi_heatpump/espmhp.cpp
+++ b/components/mitsubishi_heatpump/espmhp.cpp
@@ -686,7 +686,7 @@ void MitsubishiHeatPump::setup() {
     this->fan_mode = climate::CLIMATE_FAN_OFF;
     this->swing_mode = climate::CLIMATE_SWING_OFF;
     this->vertical_swing_state_ = "auto";
-    this->horizontal_swing_state_ = "auto";
+    this->horizontal_swing_state_ = "center";
 
 #ifdef USE_CALLBACKS
     hp->setSettingsChangedCallback(


### PR DESCRIPTION
The underlying swicago library doesn't support Auto (tried debugging it to 0x00 but no dice, must be another config register for it) "<>" is actually split so I've updated this.